### PR TITLE
Sorry, broke it with Rug

### DIFF
--- a/generator/parsers/v2_parser.py
+++ b/generator/parsers/v2_parser.py
@@ -1,4 +1,5 @@
 import pyjson5 as json
+import sys
 from generator.parsers.v1_parser import V1Parser
 from generator.rule import associate_by
 
@@ -44,8 +45,9 @@ class V2Parser(V1Parser):
                         f"{manager}.rule.{name}.extra."
                     )
                 else:
-                    raise Exception(
-                        f"Unknown header: {header} in {key} for {self.source_path}"
+                    print(
+                        f"Warning: Unknown header: {header} in {key} for {self.source_path}",
+                        file=sys.stderr
                     )
 
     def parse(self) -> None:


### PR DESCRIPTION
I used to have comments in my `RugSettings.java` file adding additional information to the rules that is only shown in the README and not in game. Today I moved the contents of those comments into the language json file [here](https://github.com/RubixDev/Rug/commit/2a4c16ae9b2b2ace4612aeeff7e18517b582ac57). Carpet just ignores these keys, but I just noticed that your script now fails with the following error:
```
Traceback (most recent call last):
  File "/home/silas/Downloads/carpet-rules-database/generator/../setup-and-run-main.py", line 8, in <module>
    main.main()
  File "/home/silas/Downloads/carpet-rules-database/generator/main.py", line 39, in main
    parser.parse()
  File "/home/silas/Downloads/carpet-rules-database/generator/parsers/v2_parser.py", line 54, in parse
    self.parse_lang_file()
  File "/home/silas/Downloads/carpet-rules-database/generator/parsers/v2_parser.py", line 47, in parse_lang_file
    raise Exception(
Exception: Unknown header: additional in carpet.rule.anvilledBlueIce.additional for RubixDev/Rug🐑1.19
```

This PR changes the `raise Exception(...)` to a simple `print(...)` to stderr.