### PR TITLE
Add default options to `COMMAND` rules

### DIFF
--- a/generator/parsers/v1_parser.py
+++ b/generator/parsers/v1_parser.py
@@ -260,6 +260,8 @@ class V1Parser(AbstractParser):
                             value = strip(match_dict["value"])
                         rule.value = self.__resolve(value)
 
+        if not rule.options and 'COMMAND' in rule.categories:
+            rule.options = ['true', 'false', 'ops', '0', '1', '2', '3', '4']
         self.rules.append(rule)
 
     def parse(self) -> None:


### PR DESCRIPTION
Many rules in the `COMMAND` category (like [`commandDraw`](https://carpet-rules.crec.dev/?name=commandDraw)) don't specify their options explicitly, but have a specific set of required options in game. This PR overrides the (empty) options list to these, when a rule has no options and is in the `COMMAND` category.
![image](https://user-images.githubusercontent.com/35602040/183057622-3eb56269-0844-4fe3-9606-d1b1d4631057.png)
