### PR TITLE
Check if rule type is String before adding command options

### DIFF
--- a/generator/parsers/v1_parser.py
+++ b/generator/parsers/v1_parser.py
@@ -260,8 +260,8 @@ class V1Parser(AbstractParser):
                             value = strip(match_dict["value"])
                         rule.value = self.__resolve(value)
 
-        if not rule.options and 'COMMAND' in rule.categories:
-            rule.options = ['true', 'false', 'ops', '0', '1', '2', '3', '4']
+        if not rule.options and "COMMAND" in rule.categories and rule.type == "String":
+            rule.options = ["true", "false", "ops", "0", "1", "2", "3", "4"]
         self.rules.append(rule)
 
     def parse(self) -> None:


### PR DESCRIPTION
This was done because `COMMAND` rules may be for example may be of type `boolean` meaning that these options do not make sense.

I think I did it correctly, but I haven't actually tested it because lazy :)