### PR TITLE
Fix repo data link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project uses a custom parser to read and process the rules from java files 
 ### Adding your repo to the database
 
 If you want to add your extension to the database,  
-please add your extension to [data/repos.json](data/repos.json) and submit a pull request.
+please add your extension to [data/repos.toml](data/repos.toml) and submit a pull request.
 
 NOTE: If different branches use different settings file, please dont put them all inside "settingsFile" property. Duplicate the object and change branch and settings file path.
 


### PR DESCRIPTION
The repository data file format was changed from `.json` to `.toml` in 2b089e57d0e7020f88cfb9abaf5211d9d293264b